### PR TITLE
reorganize Makefile to allow more flexible build, with overridable variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+/.idea/
+
+*.o
+torus

--- a/dev/Makefile
+++ b/dev/Makefile
@@ -1,12 +1,30 @@
-main: main.o controller.o logistic.o 
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz  -o torus 
-static: main.o controller.o logistic.o
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz -static -o torus.static
-main.o: main.cc 
-	g++ -c  main.cc	
+CXX=g++
+CXXFLAGS+=-O3 -Wall
+LDLIBS+=-lm -lgsl -lgslcblas -lboost_iostreams -lz
+
+UNAME_S := $(shell uname -s)
+
+# MacOS / Homebrew specific configuration
+ifeq ($(UNAME_S),Darwin)
+	CPPFLAGS+=-isystem /opt/homebrew/include # Mac libraries installed via Homebrew
+	CPPFLAGS+=-Xpreprocessor -fopenmp # Mac openmp
+	LDFLAGS+=-L/opt/homebrew/lib # Homebrew library location
+	LDLIBS+=-lomp #only need lomp on Mac OS
+endif
+
+objects = main.o controller.o logistic.o
+
+all: main
+
+main: $(objects)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(objects) $(LDLIBS) -o torus
+static: $(objects)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(objects) $(LDLIBS) -static -o torus.static
+main.o: main.cc
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c  main.cc
 controller.o: controller.cc classdef.h
-	g++    -c  controller.cc 
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c  controller.cc
 logistic.o: logistic.cc logistic.h
-	g++ -c logistic.cc -fpermissive
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c logistic.cc -fpermissive
 clean:
 	rm *.o torus	

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,12 +1,30 @@
-main: main.o controller.o logistic.o 
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz  -o torus 
-static: main.o controller.o logistic.o
-	g++  -O3 main.o controller.o logistic.o  -lm -lgsl -lgslcblas -lboost_iostreams -lz -static -o torus.static
-main.o: main.cc 
-	g++ -c  main.cc	
+CXX=g++
+CXXFLAGS+=-O3 -Wall
+LDLIBS+=-lm -lgsl -lgslcblas -lboost_iostreams -lz
+
+UNAME_S := $(shell uname -s)
+
+# MacOS / Homebrew specific configuration
+ifeq ($(UNAME_S),Darwin)
+	CPPFLAGS+=-isystem /opt/homebrew/include # Mac libraries installed via Homebrew
+	CPPFLAGS+=-Xpreprocessor -fopenmp # Mac openmp
+	LDFLAGS+=-L/opt/homebrew/lib # Homebrew library location
+	LDLIBS+=-lomp #only need lomp on Mac OS
+endif
+
+objects = main.o controller.o logistic.o
+
+all: main
+
+main: $(objects)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(objects) $(LDLIBS) -o torus
+static: $(objects)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(LDFLAGS) $(objects) $(LDLIBS) -static -o torus.static
+main.o: main.cc
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c  main.cc
 controller.o: controller.cc classdef.h
-	g++    -c  controller.cc 
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c  controller.cc
 logistic.o: logistic.cc logistic.h
-	g++ -c logistic.cc -fpermissive
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) -c logistic.cc -fpermissive
 clean:
 	rm *.o torus	


### PR DESCRIPTION
Reorganize Makefile to use overridable variables, and do basic OS detection to allow the same Makefile to be used for MacOS and Linux.

Also, this makes it easier to more consistently apply flags to the build, the current Makefile in master is not optimizing the output binary.

https://github.com/xqwen/fastenloc/pull/19 - A very similar PR applied to Fastenloc.